### PR TITLE
Fix RefrenceError on getNameHistory.js

### DIFF
--- a/src/async/getNameHistory.js
+++ b/src/async/getNameHistory.js
@@ -19,7 +19,7 @@ function getNameHistory(player_string) {
                     });
                     resolve(data);
                 })
-                .catch(err => reject(err));
+                .catch(err => console.log(err));
         });
     });
 }


### PR DESCRIPTION
Fixes ReferenceError as reject is not defined.